### PR TITLE
Do not use REMOTE_USER environment as it will clash with apache inter…

### DIFF
--- a/AuthRemoteuser.body.php
+++ b/AuthRemoteuser.body.php
@@ -162,8 +162,8 @@ class AuthRemoteuser extends MediaWiki\Session\ImmutableSessionProviderWithCooki
     {
         global $wgAuthRemoteuserDomain;
 
-        if (isset($_SERVER['REMOTE_USER'])) {
-            $username = $_SERVER['REMOTE_USER'];
+        if (isset($_SERVER['HTTP_X_REMOTE_USER'])) {
+            $username = $_SERVER['HTTP_X_REMOTE_USER'];
 
             if ($wgAuthRemoteuserDomain) {
                 $username = str_replace("$wgAuthRemoteuserDomain\\",


### PR DESCRIPTION
 Do not use REMOTE_USER environment as it will clash with apache internal authentication modules. A better approach is to use X-Remote-User header that will translate into  HTTP_X_REMOTE_USER variable in the php session; an even better approach is to have it configurable. A nice check should be provided here as well for the name and in case the name was not found, a nicer exception should be thrown in case of empty username found
